### PR TITLE
flifetime-dse

### DIFF
--- a/compilation_database_transformer/log_parser.py
+++ b/compilation_database_transformer/log_parser.py
@@ -80,6 +80,7 @@ IGNORED_OPTIONS_GCC = [
     '-fno-delete-null-pointer-checks',
     '-fno-jump-table',
     '-fno-keep-static-consts',
+    '-f(no-)?lifetime-dse',
     '-fno-strength-reduce',
     '-fno-toplevel-reorder',
     '-fno-unit-at-a-time',


### PR DESCRIPTION
Added -fno-lifetime-dse and -flifetime-dse as ignored GCC options, as Clang fail on them.